### PR TITLE
test: external contract approach for health check

### DIFF
--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -1,0 +1,958 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.6.0 <0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+struct StrategyParams {
+    uint256 performanceFee;
+    uint256 activation;
+    uint256 debtRatio;
+    uint256 minDebtPerHarvest;
+    uint256 maxDebtPerHarvest;
+    uint256 lastReport;
+    uint256 totalDebt;
+    uint256 totalGain;
+    uint256 totalLoss;
+}
+
+interface VaultAPI is IERC20 {
+    function name() external view returns (string calldata);
+
+    function symbol() external view returns (string calldata);
+
+    function decimals() external view returns (uint256);
+
+    function apiVersion() external pure returns (string memory);
+
+    function permit(
+        address owner,
+        address spender,
+        uint256 amount,
+        uint256 expiry,
+        bytes calldata signature
+    ) external returns (bool);
+
+    // NOTE: Vyper produces multiple signatures for a given function with "default" args
+    function deposit() external returns (uint256);
+
+    function deposit(uint256 amount) external returns (uint256);
+
+    function deposit(uint256 amount, address recipient)
+        external
+        returns (uint256);
+
+    // NOTE: Vyper produces multiple signatures for a given function with "default" args
+    function withdraw() external returns (uint256);
+
+    function withdraw(uint256 maxShares) external returns (uint256);
+
+    function withdraw(uint256 maxShares, address recipient)
+        external
+        returns (uint256);
+
+    function token() external view returns (address);
+
+    function strategies(address _strategy)
+        external
+        view
+        returns (StrategyParams memory);
+
+    function pricePerShare() external view returns (uint256);
+
+    function totalAssets() external view returns (uint256);
+
+    function depositLimit() external view returns (uint256);
+
+    function maxAvailableShares() external view returns (uint256);
+
+    /**
+     * View how much the Vault would increase this Strategy's borrow limit,
+     * based on its present performance (since its last report). Can be used to
+     * determine expectedReturn in your Strategy.
+     */
+    function creditAvailable() external view returns (uint256);
+
+    /**
+     * View how much the Vault would like to pull back from the Strategy,
+     * based on its present performance (since its last report). Can be used to
+     * determine expectedReturn in your Strategy.
+     */
+    function debtOutstanding() external view returns (uint256);
+
+    /**
+     * View how much the Vault expect this Strategy to return at the current
+     * block, based on its present performance (since its last report). Can be
+     * used to determine expectedReturn in your Strategy.
+     */
+    function expectedReturn() external view returns (uint256);
+
+    /**
+     * This is the main contact point where the Strategy interacts with the
+     * Vault. It is critical that this call is handled as intended by the
+     * Strategy. Therefore, this function will be called by BaseStrategy to
+     * make sure the integration is correct.
+     */
+    function report(
+        uint256 _gain,
+        uint256 _loss,
+        uint256 _debtPayment
+    ) external returns (uint256);
+
+    /**
+     * This function should only be used in the scenario where the Strategy is
+     * being retired but no migration of the positions are possible, or in the
+     * extreme scenario that the Strategy needs to be put into "Emergency Exit"
+     * mode in order for it to exit as quickly as possible. The latter scenario
+     * could be for any reason that is considered "critical" that the Strategy
+     * exits its position as fast as possible, such as a sudden change in
+     * market conditions leading to losses, or an imminent failure in an
+     * external dependency.
+     */
+    function revokeStrategy() external;
+
+    /**
+     * View the governance address of the Vault to assert privileged functions
+     * can only be called by governance. The Strategy serves the Vault, so it
+     * is subject to governance defined by the Vault.
+     */
+    function governance() external view returns (address);
+
+    /**
+     * View the management address of the Vault to assert privileged functions
+     * can only be called by management. The Strategy serves the Vault, so it
+     * is subject to management defined by the Vault.
+     */
+    function management() external view returns (address);
+
+    /**
+     * View the guardian address of the Vault to assert privileged functions
+     * can only be called by guardian. The Strategy serves the Vault, so it
+     * is subject to guardian defined by the Vault.
+     */
+    function guardian() external view returns (address);
+}
+
+/**
+ * This interface is here for the keeper bot to use.
+ */
+interface StrategyAPI {
+    function name() external view returns (string memory);
+
+    function vault() external view returns (address);
+
+    function want() external view returns (address);
+
+    function apiVersion() external pure returns (string memory);
+
+    function keeper() external view returns (address);
+
+    function isActive() external view returns (bool);
+
+    function delegatedAssets() external view returns (uint256);
+
+    function estimatedTotalAssets() external view returns (uint256);
+
+    function tendTrigger(uint256 callCost) external view returns (bool);
+
+    function tend() external;
+
+    function harvestTrigger(uint256 callCost) external view returns (bool);
+
+    function harvest() external;
+
+    event Harvested(
+        uint256 profit,
+        uint256 loss,
+        uint256 debtPayment,
+        uint256 debtOutstanding
+    );
+}
+
+interface HealthCheck {
+    // TODO: maybe a uint256 dynamic array with 10 args is more flexible instead of set args?
+    function check(
+        uint256 profit,
+        uint256 loss,
+        uint256 debtPayment,
+        uint256 debtOutstanding
+    ) external view returns (bool);
+}
+
+/**
+ * @title Yearn Base Strategy
+ * @author yearn.finance
+ * @notice
+ *  BaseStrategy implements all of the required functionality to interoperate
+ *  closely with the Vault contract. This contract should be inherited and the
+ *  abstract methods implemented to adapt the Strategy to the particular needs
+ *  it has to create a return.
+ *
+ *  Of special interest is the relationship between `harvest()` and
+ *  `vault.report()'. `harvest()` may be called simply because enough time has
+ *  elapsed since the last report, and not because any funds need to be moved
+ *  or positions adjusted. This is critical so that the Vault may maintain an
+ *  accurate picture of the Strategy's performance. See  `vault.report()`,
+ *  `harvest()`, and `harvestTrigger()` for further details.
+ */
+abstract contract BaseStrategy {
+    using SafeMath for uint256;
+    using SafeERC20 for IERC20;
+    string public metadataURI;
+
+    // health checks
+    bool public doHealthCheck;
+    address public healthCheck;
+
+    /**
+     * @notice
+     *  Used to track which version of `StrategyAPI` this Strategy
+     *  implements.
+     * @dev The Strategy's version must match the Vault's `API_VERSION`.
+     * @return A string which holds the current API version of this contract.
+     */
+    function apiVersion() public pure returns (string memory) {
+        return "0.3.5";
+    }
+
+    /**
+     * @notice This Strategy's name.
+     * @dev
+     *  You can use this field to manage the "version" of this Strategy, e.g.
+     *  `StrategySomethingOrOtherV1`. However, "API Version" is managed by
+     *  `apiVersion()` function above.
+     * @return This Strategy's name.
+     */
+    function name() external view virtual returns (string memory);
+
+    /**
+     * @notice
+     *  The amount (priced in want) of the total assets managed by this strategy should not count
+     *  towards Yearn's TVL calculations.
+     * @dev
+     *  You can override this field to set it to a non-zero value if some of the assets of this
+     *  Strategy is somehow delegated inside another part of of Yearn's ecosystem e.g. another Vault.
+     *  Note that this value must be strictly less than or equal to the amount provided by
+     *  `estimatedTotalAssets()` below, as the TVL calc will be total assets minus delegated assets.
+     *  Also note that this value is used to determine the total assets under management by this
+     *  strategy, for the purposes of computing the management fee in `Vault`
+     * @return
+     *  The amount of assets this strategy manages that should not be included in Yearn's Total Value
+     *  Locked (TVL) calculation across it's ecosystem.
+     */
+    function delegatedAssets() external view virtual returns (uint256) {
+        return 0;
+    }
+
+    VaultAPI public vault;
+    address public strategist;
+    address public rewards;
+    address public keeper;
+
+    IERC20 public want;
+
+    // So indexers can keep track of this
+    event Harvested(
+        uint256 profit,
+        uint256 loss,
+        uint256 debtPayment,
+        uint256 debtOutstanding
+    );
+
+    event UpdatedStrategist(address newStrategist);
+
+    event UpdatedKeeper(address newKeeper);
+
+    event UpdatedRewards(address rewards);
+
+    event UpdatedMinReportDelay(uint256 delay);
+
+    event UpdatedMaxReportDelay(uint256 delay);
+
+    event UpdatedProfitFactor(uint256 profitFactor);
+
+    event UpdatedDebtThreshold(uint256 debtThreshold);
+
+    event EmergencyExitEnabled();
+
+    event UpdatedMetadataURI(string metadataURI);
+
+    // The minimum number of seconds between harvest calls. See
+    // `setMinReportDelay()` for more details.
+    uint256 public minReportDelay;
+
+    // The maximum number of seconds between harvest calls. See
+    // `setMaxReportDelay()` for more details.
+    uint256 public maxReportDelay;
+
+    // The minimum multiple that `callCost` must be above the credit/profit to
+    // be "justifiable". See `setProfitFactor()` for more details.
+    uint256 public profitFactor;
+
+    // Use this to adjust the threshold at which running a debt causes a
+    // harvest trigger. See `setDebtThreshold()` for more details.
+    uint256 public debtThreshold;
+
+    // See note on `setEmergencyExit()`.
+    bool public emergencyExit;
+
+    // modifiers
+    modifier onlyAuthorized() {
+        require(
+            msg.sender == strategist || msg.sender == governance(),
+            "!authorized"
+        );
+        _;
+    }
+
+    modifier onlyStrategist() {
+        require(msg.sender == strategist, "!strategist");
+        _;
+    }
+
+    modifier onlyGovernance() {
+        require(msg.sender == governance(), "!authorized");
+        _;
+    }
+
+    modifier onlyKeepers() {
+        require(
+            msg.sender == keeper ||
+                msg.sender == strategist ||
+                msg.sender == governance() ||
+                msg.sender == vault.guardian() ||
+                msg.sender == vault.management(),
+            "!authorized"
+        );
+        _;
+    }
+
+    modifier onlyVaultManagers() {
+        require(
+            msg.sender == vault.management() || msg.sender == governance(),
+            "!authorized"
+        );
+        _;
+    }
+
+    constructor(address _vault) public {
+        _initialize(_vault, msg.sender, msg.sender, msg.sender);
+    }
+
+    /**
+     * @notice
+     *  Initializes the Strategy, this is called only once, when the
+     *  contract is deployed.
+     * @dev `_vault` should implement `VaultAPI`.
+     * @param _vault The address of the Vault responsible for this Strategy.
+     */
+    function _initialize(
+        address _vault,
+        address _strategist,
+        address _rewards,
+        address _keeper
+    ) internal {
+        require(address(want) == address(0), "Strategy already initialized");
+
+        vault = VaultAPI(_vault);
+        want = IERC20(vault.token());
+        want.safeApprove(_vault, uint256(-1)); // Give Vault unlimited access (might save gas)
+        strategist = _strategist;
+        rewards = _rewards;
+        keeper = _keeper;
+
+        // initialize variables
+        minReportDelay = 0;
+        maxReportDelay = 86400;
+        profitFactor = 100;
+        debtThreshold = 0;
+
+        vault.approve(rewards, uint256(-1)); // Allow rewards to be pulled
+    }
+
+    function setHealthCheck(address _healthCheck) external onlyVaultManagers {
+        healthCheck = _healthCheck;
+    }
+
+    function setDoHealthCheck(bool _doHealthCheck) external onlyVaultManagers {
+        doHealthCheck = _doHealthCheck;
+    }
+
+    /**
+     * @notice
+     *  Used to change `strategist`.
+     *
+     *  This may only be called by governance or the existing strategist.
+     * @param _strategist The new address to assign as `strategist`.
+     */
+    function setStrategist(address _strategist) external onlyAuthorized {
+        require(_strategist != address(0));
+        strategist = _strategist;
+        emit UpdatedStrategist(_strategist);
+    }
+
+    /**
+     * @notice
+     *  Used to change `keeper`.
+     *
+     *  `keeper` is the only address that may call `tend()` or `harvest()`,
+     *  other than `governance()` or `strategist`. However, unlike
+     *  `governance()` or `strategist`, `keeper` may *only* call `tend()`
+     *  and `harvest()`, and no other authorized functions, following the
+     *  principle of least privilege.
+     *
+     *  This may only be called by governance or the strategist.
+     * @param _keeper The new address to assign as `keeper`.
+     */
+    function setKeeper(address _keeper) external onlyAuthorized {
+        require(_keeper != address(0));
+        keeper = _keeper;
+        emit UpdatedKeeper(_keeper);
+    }
+
+    /**
+     * @notice
+     *  Used to change `rewards`. EOA or smart contract which has the permission
+     *  to pull rewards from the vault.
+     *
+     *  This may only be called by the strategist.
+     * @param _rewards The address to use for pulling rewards.
+     */
+    function setRewards(address _rewards) external onlyStrategist {
+        require(_rewards != address(0));
+        vault.approve(rewards, 0);
+        rewards = _rewards;
+        vault.approve(rewards, uint256(-1));
+        emit UpdatedRewards(_rewards);
+    }
+
+    /**
+     * @notice
+     *  Used to change `minReportDelay`. `minReportDelay` is the minimum number
+     *  of blocks that should pass for `harvest()` to be called.
+     *
+     *  For external keepers (such as the Keep3r network), this is the minimum
+     *  time between jobs to wait. (see `harvestTrigger()`
+     *  for more details.)
+     *
+     *  This may only be called by governance or the strategist.
+     * @param _delay The minimum number of seconds to wait between harvests.
+     */
+    function setMinReportDelay(uint256 _delay) external onlyAuthorized {
+        minReportDelay = _delay;
+        emit UpdatedMinReportDelay(_delay);
+    }
+
+    /**
+     * @notice
+     *  Used to change `maxReportDelay`. `maxReportDelay` is the maximum number
+     *  of blocks that should pass for `harvest()` to be called.
+     *
+     *  For external keepers (such as the Keep3r network), this is the maximum
+     *  time between jobs to wait. (see `harvestTrigger()`
+     *  for more details.)
+     *
+     *  This may only be called by governance or the strategist.
+     * @param _delay The maximum number of seconds to wait between harvests.
+     */
+    function setMaxReportDelay(uint256 _delay) external onlyAuthorized {
+        maxReportDelay = _delay;
+        emit UpdatedMaxReportDelay(_delay);
+    }
+
+    /**
+     * @notice
+     *  Used to change `profitFactor`. `profitFactor` is used to determine
+     *  if it's worthwhile to harvest, given gas costs. (See `harvestTrigger()`
+     *  for more details.)
+     *
+     *  This may only be called by governance or the strategist.
+     * @param _profitFactor A ratio to multiply anticipated
+     * `harvest()` gas cost against.
+     */
+    function setProfitFactor(uint256 _profitFactor) external onlyAuthorized {
+        profitFactor = _profitFactor;
+        emit UpdatedProfitFactor(_profitFactor);
+    }
+
+    /**
+     * @notice
+     *  Sets how far the Strategy can go into loss without a harvest and report
+     *  being required.
+     *
+     *  By default this is 0, meaning any losses would cause a harvest which
+     *  will subsequently report the loss to the Vault for tracking. (See
+     *  `harvestTrigger()` for more details.)
+     *
+     *  This may only be called by governance or the strategist.
+     * @param _debtThreshold How big of a loss this Strategy may carry without
+     * being required to report to the Vault.
+     */
+    function setDebtThreshold(uint256 _debtThreshold) external onlyAuthorized {
+        debtThreshold = _debtThreshold;
+        emit UpdatedDebtThreshold(_debtThreshold);
+    }
+
+    /**
+     * @notice
+     *  Used to change `metadataURI`. `metadataURI` is used to store the URI
+     * of the file describing the strategy.
+     *
+     *  This may only be called by governance or the strategist.
+     * @param _metadataURI The URI that describe the strategy.
+     */
+    function setMetadataURI(string calldata _metadataURI)
+        external
+        onlyAuthorized
+    {
+        metadataURI = _metadataURI;
+        emit UpdatedMetadataURI(_metadataURI);
+    }
+
+    /**
+     * Resolve governance address from Vault contract, used to make assertions
+     * on protected functions in the Strategy.
+     */
+    function governance() internal view returns (address) {
+        return vault.governance();
+    }
+
+    /**
+     * @notice
+     *  Provide an accurate estimate for the total amount of assets
+     *  (principle + return) that this Strategy is currently managing,
+     *  denominated in terms of `want` tokens.
+     *
+     *  This total should be "realizable" e.g. the total value that could
+     *  *actually* be obtained from this Strategy if it were to divest its
+     *  entire position based on current on-chain conditions.
+     * @dev
+     *  Care must be taken in using this function, since it relies on external
+     *  systems, which could be manipulated by the attacker to give an inflated
+     *  (or reduced) value produced by this function, based on current on-chain
+     *  conditions (e.g. this function is possible to influence through
+     *  flashloan attacks, oracle manipulations, or other DeFi attack
+     *  mechanisms).
+     *
+     *  It is up to governance to use this function to correctly order this
+     *  Strategy relative to its peers in the withdrawal queue to minimize
+     *  losses for the Vault based on sudden withdrawals. This value should be
+     *  higher than the total debt of the Strategy and higher than its expected
+     *  value to be "safe".
+     * @return The estimated total assets in this Strategy.
+     */
+    function estimatedTotalAssets() public view virtual returns (uint256);
+
+    /*
+     * @notice
+     *  Provide an indication of whether this strategy is currently "active"
+     *  in that it is managing an active position, or will manage a position in
+     *  the future. This should correlate to `harvest()` activity, so that Harvest
+     *  events can be tracked externally by indexing agents.
+     * @return True if the strategy is actively managing a position.
+     */
+    function isActive() public view returns (bool) {
+        return
+            vault.strategies(address(this)).debtRatio > 0 ||
+            estimatedTotalAssets() > 0;
+    }
+
+    /**
+     * Perform any Strategy unwinding or other calls necessary to capture the
+     * "free return" this Strategy has generated since the last time its core
+     * position(s) were adjusted. Examples include unwrapping extra rewards.
+     * This call is only used during "normal operation" of a Strategy, and
+     * should be optimized to minimize losses as much as possible.
+     *
+     * This method returns any realized profits and/or realized losses
+     * incurred, and should return the total amounts of profits/losses/debt
+     * payments (in `want` tokens) for the Vault's accounting (e.g.
+     * `want.balanceOf(this) >= _debtPayment + _profit - _loss`).
+     *
+     * `_debtOutstanding` will be 0 if the Strategy is not past the configured
+     * debt limit, otherwise its value will be how far past the debt limit
+     * the Strategy is. The Strategy's debt limit is configured in the Vault.
+     *
+     * NOTE: `_debtPayment` should be less than or equal to `_debtOutstanding`.
+     *       It is okay for it to be less than `_debtOutstanding`, as that
+     *       should only used as a guide for how much is left to pay back.
+     *       Payments should be made to minimize loss from slippage, debt,
+     *       withdrawal fees, etc.
+     *
+     * See `vault.debtOutstanding()`.
+     */
+    function prepareReturn(uint256 _debtOutstanding)
+        internal
+        virtual
+        returns (
+            uint256 _profit,
+            uint256 _loss,
+            uint256 _debtPayment
+        );
+
+    /**
+     * Perform any adjustments to the core position(s) of this Strategy given
+     * what change the Vault made in the "investable capital" available to the
+     * Strategy. Note that all "free capital" in the Strategy after the report
+     * was made is available for reinvestment. Also note that this number
+     * could be 0, and you should handle that scenario accordingly.
+     *
+     * See comments regarding `_debtOutstanding` on `prepareReturn()`.
+     */
+    function adjustPosition(uint256 _debtOutstanding) internal virtual;
+
+    /**
+     * Liquidate up to `_amountNeeded` of `want` of this strategy's positions,
+     * irregardless of slippage. Any excess will be re-invested with `adjustPosition()`.
+     * This function should return the amount of `want` tokens made available by the
+     * liquidation. If there is a difference between them, `_loss` indicates whether the
+     * difference is due to a realized loss, or if there is some other sitution at play
+     * (e.g. locked funds) where the amount made available is less than what is needed.
+     * This function is used during emergency exit instead of `prepareReturn()` to
+     * liquidate all of the Strategy's positions back to the Vault.
+     *
+     * NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always be maintained
+     */
+    function liquidatePosition(uint256 _amountNeeded)
+        internal
+        virtual
+        returns (uint256 _liquidatedAmount, uint256 _loss);
+
+    /**
+     * @notice
+     *  Provide a signal to the keeper that `tend()` should be called. The
+     *  keeper will provide the estimated gas cost that they would pay to call
+     *  `tend()`, and this function should use that estimate to make a
+     *  determination if calling it is "worth it" for the keeper. This is not
+     *  the only consideration into issuing this trigger, for example if the
+     *  position would be negatively affected if `tend()` is not called
+     *  shortly, then this can return `true` even if the keeper might be
+     *  "at a loss" (keepers are always reimbursed by Yearn).
+     * @dev
+     *  `callCost` must be priced in terms of `want`.
+     *
+     *  This call and `harvestTrigger()` should never return `true` at the same
+     *  time.
+     * @param callCost The keeper's estimated cast cost to call `tend()`.
+     * @return `true` if `tend()` should be called, `false` otherwise.
+     */
+    function tendTrigger(uint256 callCost) public view virtual returns (bool) {
+        // We usually don't need tend, but if there are positions that need
+        // active maintainence, overriding this function is how you would
+        // signal for that.
+        return false;
+    }
+
+    /**
+     * @notice
+     *  Adjust the Strategy's position. The purpose of tending isn't to
+     *  realize gains, but to maximize yield by reinvesting any returns.
+     *
+     *  See comments on `adjustPosition()`.
+     *
+     *  This may only be called by governance, the strategist, or the keeper.
+     */
+    function tend() external onlyKeepers {
+        // Don't take profits with this call, but adjust for better gains
+        adjustPosition(vault.debtOutstanding());
+    }
+
+    /**
+     * @notice
+     *  Provide a signal to the keeper that `harvest()` should be called. The
+     *  keeper will provide the estimated gas cost that they would pay to call
+     *  `harvest()`, and this function should use that estimate to make a
+     *  determination if calling it is "worth it" for the keeper. This is not
+     *  the only consideration into issuing this trigger, for example if the
+     *  position would be negatively affected if `harvest()` is not called
+     *  shortly, then this can return `true` even if the keeper might be "at a
+     *  loss" (keepers are always reimbursed by Yearn).
+     * @dev
+     *  `callCost` must be priced in terms of `want`.
+     *
+     *  This call and `tendTrigger` should never return `true` at the
+     *  same time.
+     *
+     *  See `min/maxReportDelay`, `profitFactor`, `debtThreshold` to adjust the
+     *  strategist-controlled parameters that will influence whether this call
+     *  returns `true` or not. These parameters will be used in conjunction
+     *  with the parameters reported to the Vault (see `params`) to determine
+     *  if calling `harvest()` is merited.
+     *
+     *  It is expected that an external system will check `harvestTrigger()`.
+     *  This could be a script run off a desktop or cloud bot (e.g.
+     *  https://github.com/iearn-finance/yearn-vaults/blob/master/scripts/keep.py),
+     *  or via an integration with the Keep3r network (e.g.
+     *  https://github.com/Macarse/GenericKeep3rV2/blob/master/contracts/keep3r/GenericKeep3rV2.sol).
+     * @param callCost The keeper's estimated cast cost to call `harvest()`.
+     * @return `true` if `harvest()` should be called, `false` otherwise.
+     */
+    function harvestTrigger(uint256 callCost)
+        public
+        view
+        virtual
+        returns (bool)
+    {
+        StrategyParams memory params = vault.strategies(address(this));
+
+        // Should not trigger if Strategy is not activated
+        if (params.activation == 0) return false;
+
+        // Should not trigger if we haven't waited long enough since previous harvest
+        if (block.timestamp.sub(params.lastReport) < minReportDelay)
+            return false;
+
+        // Should trigger if hasn't been called in a while
+        if (block.timestamp.sub(params.lastReport) >= maxReportDelay)
+            return true;
+
+        // If some amount is owed, pay it back
+        // NOTE: Since debt is based on deposits, it makes sense to guard against large
+        //       changes to the value from triggering a harvest directly through user
+        //       behavior. This should ensure reasonable resistance to manipulation
+        //       from user-initiated withdrawals as the outstanding debt fluctuates.
+        uint256 outstanding = vault.debtOutstanding();
+        if (outstanding > debtThreshold) return true;
+
+        // Check for profits and losses
+        uint256 total = estimatedTotalAssets();
+        // Trigger if we have a loss to report
+        if (total.add(debtThreshold) < params.totalDebt) return true;
+
+        uint256 profit = 0;
+        if (total > params.totalDebt) profit = total.sub(params.totalDebt); // We've earned a profit!
+
+        // Otherwise, only trigger if it "makes sense" economically (gas cost
+        // is <N% of value moved)
+        uint256 credit = vault.creditAvailable();
+        return (profitFactor.mul(callCost) < credit.add(profit));
+    }
+
+    /**
+     * @notice
+     *  Harvests the Strategy, recognizing any profits or losses and adjusting
+     *  the Strategy's position.
+     *
+     *  In the rare case the Strategy is in emergency shutdown, this will exit
+     *  the Strategy's position.
+     *
+     *  This may only be called by governance, the strategist, or the keeper.
+     * @dev
+     *  When `harvest()` is called, the Strategy reports to the Vault (via
+     *  `vault.report()`), so in some cases `harvest()` must be called in order
+     *  to take in profits, to borrow newly available funds from the Vault, or
+     *  otherwise adjust its position. In other cases `harvest()` must be
+     *  called to report to the Vault on the Strategy's position, especially if
+     *  any losses have occurred.
+     */
+    function harvest() external onlyKeepers {
+        uint256 profit = 0;
+        uint256 loss = 0;
+        uint256 debtOutstanding = vault.debtOutstanding();
+        uint256 debtPayment = 0;
+        if (emergencyExit) {
+            // Free up as much capital as possible
+            uint256 totalAssets = estimatedTotalAssets();
+            // NOTE: use the larger of total assets or debt outstanding to book losses properly
+            (debtPayment, loss) = liquidatePosition(
+                totalAssets > debtOutstanding ? totalAssets : debtOutstanding
+            );
+            // NOTE: take up any remainder here as profit
+            if (debtPayment > debtOutstanding) {
+                profit = debtPayment.sub(debtOutstanding);
+                debtPayment = debtOutstanding;
+            }
+        } else {
+            // Free up returns for Vault to pull
+            (profit, loss, debtPayment) = prepareReturn(debtOutstanding);
+        }
+
+        // Allow Vault to take up to the "harvested" balance of this contract,
+        // which is the amount it has earned since the last time it reported to
+        // the Vault.
+        debtOutstanding = vault.report(profit, loss, debtPayment);
+
+        // Check if free returns are left, and re-invest them
+        adjustPosition(debtOutstanding);
+
+        // call healthCheck contract
+        if (doHealthCheck && healthCheck != address(0)) {
+            require(
+                HealthCheck(healthCheck).check(
+                    profit,
+                    loss,
+                    debtPayment,
+                    debtOutstanding
+                ),
+                "!healthcheck"
+            );
+        } else {
+            doHealthCheck = true;
+        }
+
+        emit Harvested(profit, loss, debtPayment, debtOutstanding);
+    }
+
+    /**
+     * @notice
+     *  Withdraws `_amountNeeded` to `vault`.
+     *
+     *  This may only be called by the Vault.
+     * @param _amountNeeded How much `want` to withdraw.
+     * @return _loss Any realized losses
+     */
+    function withdraw(uint256 _amountNeeded) external returns (uint256 _loss) {
+        require(msg.sender == address(vault), "!vault");
+        // Liquidate as much as possible to `want`, up to `_amountNeeded`
+        uint256 amountFreed;
+        (amountFreed, _loss) = liquidatePosition(_amountNeeded);
+        // Send it directly back (NOTE: Using `msg.sender` saves some gas here)
+        want.safeTransfer(msg.sender, amountFreed);
+        // NOTE: Reinvest anything leftover on next `tend`/`harvest`
+    }
+
+    /**
+     * Do anything necessary to prepare this Strategy for migration, such as
+     * transferring any reserve or LP tokens, CDPs, or other tokens or stores of
+     * value.
+     */
+    function prepareMigration(address _newStrategy) internal virtual;
+
+    /**
+     * @notice
+     *  Transfers all `want` from this Strategy to `_newStrategy`.
+     *
+     *  This may only be called by governance or the Vault.
+     * @dev
+     *  The new Strategy's Vault must be the same as this Strategy's Vault.
+     * @param _newStrategy The Strategy to migrate to.
+     */
+    function migrate(address _newStrategy) external {
+        require(msg.sender == address(vault) || msg.sender == governance());
+        require(BaseStrategy(_newStrategy).vault() == vault);
+        prepareMigration(_newStrategy);
+        want.safeTransfer(_newStrategy, want.balanceOf(address(this)));
+    }
+
+    /**
+     * @notice
+     *  Activates emergency exit. Once activated, the Strategy will exit its
+     *  position upon the next harvest, depositing all funds into the Vault as
+     *  quickly as is reasonable given on-chain conditions.
+     *
+     *  This may only be called by governance or the strategist.
+     * @dev
+     *  See `vault.setEmergencyShutdown()` and `harvest()` for further details.
+     */
+    function setEmergencyExit() external onlyAuthorized {
+        emergencyExit = true;
+        vault.revokeStrategy();
+
+        emit EmergencyExitEnabled();
+    }
+
+    /**
+     * Override this to add all tokens/tokenized positions this contract
+     * manages on a *persistent* basis (e.g. not just for swapping back to
+     * want ephemerally).
+     *
+     * NOTE: Do *not* include `want`, already included in `sweep` below.
+     *
+     * Example:
+     *
+     *    function protectedTokens() internal override view returns (address[] memory) {
+     *      address[] memory protected = new address[](3);
+     *      protected[0] = tokenA;
+     *      protected[1] = tokenB;
+     *      protected[2] = tokenC;
+     *      return protected;
+     *    }
+     */
+    function protectedTokens() internal view virtual returns (address[] memory);
+
+    /**
+     * @notice
+     *  Removes tokens from this Strategy that are not the type of tokens
+     *  managed by this Strategy. This may be used in case of accidentally
+     *  sending the wrong kind of token to this Strategy.
+     *
+     *  Tokens will be sent to `governance()`.
+     *
+     *  This will fail if an attempt is made to sweep `want`, or any tokens
+     *  that are protected by this Strategy.
+     *
+     *  This may only be called by governance.
+     * @dev
+     *  Implement `protectedTokens()` to specify any additional tokens that
+     *  should be protected from sweeping in addition to `want`.
+     * @param _token The token to transfer out of this vault.
+     */
+    function sweep(address _token) external onlyGovernance {
+        require(_token != address(want), "!want");
+        require(_token != address(vault), "!shares");
+
+        address[] memory _protectedTokens = protectedTokens();
+        for (uint256 i; i < _protectedTokens.length; i++)
+            require(_token != _protectedTokens[i], "!protected");
+
+        IERC20(_token).safeTransfer(
+            governance(),
+            IERC20(_token).balanceOf(address(this))
+        );
+    }
+}
+
+abstract contract BaseStrategyInitializable is BaseStrategy {
+    event Cloned(address indexed clone);
+
+    constructor(address _vault) public BaseStrategy(_vault) {}
+
+    function initialize(
+        address _vault,
+        address _strategist,
+        address _rewards,
+        address _keeper
+    ) external virtual {
+        _initialize(_vault, _strategist, _rewards, _keeper);
+    }
+
+    function clone(address _vault) external returns (address) {
+        return this.clone(_vault, msg.sender, msg.sender, msg.sender);
+    }
+
+    function clone(
+        address _vault,
+        address _strategist,
+        address _rewards,
+        address _keeper
+    ) external returns (address newStrategy) {
+        // Copied from https://github.com/optionality/clone-factory/blob/master/contracts/CloneFactory.sol
+        bytes20 addressBytes = bytes20(address(this));
+
+        assembly {
+            // EIP-1167 bytecode
+            let clone_code := mload(0x40)
+            mstore(
+                clone_code,
+                0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000
+            )
+            mstore(add(clone_code, 0x14), addressBytes)
+            mstore(
+                add(clone_code, 0x28),
+                0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000
+            )
+            newStrategy := create(0, clone_code, 0x37)
+        }
+
+        BaseStrategyInitializable(newStrategy).initialize(
+            _vault,
+            _strategist,
+            _rewards,
+            _keeper
+        );
+
+        emit Cloned(newStrategy);
+    }
+}

--- a/contracts/CommonHealthCheck.sol
+++ b/contracts/CommonHealthCheck.sol
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.6.0 <0.7.0;
+pragma experimental ABIEncoderV2;
+
+struct StrategyParams {
+    uint256 performanceFee;
+    uint256 activation;
+    uint256 debtRatio;
+    uint256 minDebtPerHarvest;
+    uint256 maxDebtPerHarvest;
+    uint256 lastReport;
+    uint256 totalDebt;
+    uint256 totalGain;
+    uint256 totalLoss;
+}
+
+interface VaultAPI {
+    function strategies(address _strategy)
+        external
+        view
+        returns (StrategyParams memory);
+}
+
+interface StrategyAPI {
+    function vault() external view returns (address);
+}
+
+interface CustomHealthCheck {
+    function check(
+        uint256 profit,
+        uint256 loss,
+        uint256 debtPayment,
+        uint256 debtOutstanding,
+        address callerStrategy
+    ) external view returns (bool);
+}
+
+// LEGACY INTERFACES PRE 0.3.2
+struct LegacyStrategyParams {
+    uint256 performanceFee;
+    uint256 activation;
+    uint256 debtRatio;
+    uint256 rateLimit;
+    uint256 lastReport;
+    uint256 totalDebt;
+    uint256 totalGain;
+    uint256 totalLoss;
+}
+
+interface LegacyVaultAPI {
+    function strategies(address _strategy)
+        external
+        view
+        returns (LegacyStrategyParams memory);
+}
+
+contract CommonHealthCheck {
+    // Global Settings for all strategies
+    uint256 constant MAX_BPS = 10_000;
+    uint256 public profitLimitRatio;
+    uint256 public lossLimitRatio;
+
+    address public governance;
+    address public management;
+
+    mapping(address => address) public checks;
+
+    modifier onlyGovernance() {
+        require(msg.sender == governance, "!authorized");
+        _;
+    }
+
+    modifier onlyAuthorized() {
+        require(
+            msg.sender == governance || msg.sender == management,
+            "!authorized"
+        );
+        _;
+    }
+
+    constructor(address _vault) public {
+        governance = msg.sender;
+        management = msg.sender;
+    }
+
+    function setGovernance(address _governance) external onlyGovernance {
+        require(_governance != address(0));
+        governance = _governance;
+    }
+
+    function setManagement(address _management) external onlyGovernance {
+        require(_management != address(0));
+        management = _management;
+    }
+
+    function setCheck(address _strategy, address _check)
+        external
+        onlyAuthorized
+    {
+        checks[_strategy] = _check;
+    }
+
+    function check(
+        uint256 profit,
+        uint256 loss,
+        uint256 debtPayment,
+        uint256 debtOutstanding
+    ) external view returns (bool) {
+        address vault = StrategyAPI(msg.sender).vault();
+        uint256 totalDebt = VaultAPI(vault).strategies(address(this)).totalDebt;
+
+        return
+            _runChecks(profit, loss, debtPayment, debtOutstanding, totalDebt);
+    }
+
+    // unfortunately we need a different method to interact with 0.3.0 vaults that are in prod because
+    // of different interfaces
+    function checkLegacy(
+        uint256 profit,
+        uint256 loss,
+        uint256 debtPayment,
+        uint256 debtOutstanding
+    ) external view returns (bool) {
+        address vault = StrategyAPI(msg.sender).vault();
+        uint256 totalDebt =
+            LegacyVaultAPI(vault).strategies(address(this)).totalDebt;
+
+        return
+            _runChecks(profit, loss, debtPayment, debtOutstanding, totalDebt);
+    }
+
+    function _runChecks(
+        uint256 profit,
+        uint256 loss,
+        uint256 debtPayment,
+        uint256 debtOutstanding,
+        uint256 totalDebt
+    ) internal view returns (bool) {
+        address customCheck = checks[msg.sender];
+
+        if (customCheck == address(0)) {
+            return _executeDefaultCheck(profit, loss, totalDebt);
+        }
+
+        return
+            CustomHealthCheck(customCheck).check(
+                profit,
+                loss,
+                debtPayment,
+                debtOutstanding,
+                msg.sender
+            );
+    }
+
+    function _executeDefaultCheck(
+        uint256 _profit,
+        uint256 _loss,
+        uint256 _totalDebt
+    ) internal view returns (bool) {
+        if (_profit <= (_totalDebt * profitLimitRatio) / MAX_BPS) {
+            return false;
+        }
+        if (_loss <= (_totalDebt * lossLimitRatio) / MAX_BPS) {
+            return false;
+        }
+        // health checks pass
+        return true;
+    }
+}


### PR DESCRIPTION
This test uses an external healthcheck contract that the BaseStrategy has reference and calls after harvest side effects, adds little to no additional state to contract size from initial testing.

Can validate comparing this branch against original branch in master with `brownie compile --size`

Before fix:
<img width="661" alt="Screen Shot 2021-06-01 at 18 02 04" src="https://user-images.githubusercontent.com/6074987/120404399-847c7800-c303-11eb-9067-8a06f5fd015c.png">

After Fix: 

<img width="776" alt="Screen Shot 2021-06-01 at 17 59 59" src="https://user-images.githubusercontent.com/6074987/120404339-6151c880-c303-11eb-910c-3c0ac3b0c747.png">
